### PR TITLE
Panda Wallet - change satAmount to satoshis

### DIFF
--- a/src/context/bitcoin/index.js
+++ b/src/context/bitcoin/index.js
@@ -484,7 +484,7 @@ const BitcoinProvider = (props) => {
           const { txid, rawtx } = await sendBsv([
             {
               script: scriptP.toHex(),
-              satAmount: 0,
+              satoshis: 0,
             },
           ]);
           console.log({ txid });


### PR DESCRIPTION
Updates the property name for sending transactions using Panda Wallet, which fixes the bug of not being able to send messages if you're logged in using Panda Wallet.

The Panda Wallet API change happened in this [commit](https://github.com/Panda-Wallet/panda-wallet/commit/776eb119664668720ec81295ca74cf95d692c4a0#diff-5b8aa3226afb0621795466b03797777ec21b76cce51c7aee5425b989e72e8f66L32).