### PR TITLE
File uploads

### DIFF
--- a/src/components/dashboard/FileRenderer.js
+++ b/src/components/dashboard/FileRenderer.js
@@ -1,0 +1,67 @@
+import { forwardRef, useState } from "react";
+
+const mediaElement = {
+  image: "img",
+  video: "video",
+  audio: "audio",
+};
+
+const mediaElementProps = {
+  image: {},
+  video: {
+    className: "object-contain w-full h-full",
+    controls: true,
+  },
+  audio: {
+    className: "w-full",
+    controls: true,
+  },
+};
+
+/**
+ * Renders a file based on its type.
+ *
+ * @param {Object} props - The component props.
+ * @param {string} props.type - The type of the file.
+ * @param {string} props.data - The base64 data of the file.
+ * @returns {JSX.Element|null} The rendered file component or null if the file type is not supported.
+ */
+export const FileRenderer = forwardRef(({ type, data, onClick }, ref) => {
+  const [hasError, setHasError] = useState(false);
+  const MediaElement = mediaElement[type];
+
+  function handleClick() {
+    /**
+     * We're only handling the click event for images here,
+     * since the other media types have their own controls.
+     */
+    if (type === "image" && onClick) {
+      onClick();
+    }
+  }
+
+  if (!MediaElement) {
+    return null;
+  }
+
+  return (
+    <div className="relative w-full h-full">
+      <MediaElement
+        ref={ref}
+        src={data}
+        onLoad={() => setHasError(false)}
+        onError={() => setHasError(true)}
+        {...mediaElementProps[type]}
+        onClick={handleClick}
+      />
+
+      {hasError && (
+        <div className="flex items-center justify-center absolute inset-0 bg-gray-800">
+          <span className="text-sm font-medium text-red-400 select-none">
+            Failed to load file
+          </span>
+        </div>
+      )}
+    </div>
+  );
+});

--- a/src/components/dashboard/MessageFile.js
+++ b/src/components/dashboard/MessageFile.js
@@ -1,0 +1,44 @@
+import { useMemo } from "react";
+import styled from "styled-components";
+import { getBase64Url } from "../../utils/file";
+import { FileRenderer } from "./FileRenderer";
+
+const Container = styled.div`
+  flex: 1;
+  border-radius: 8px;
+  overflow: hidden;
+  min-width: 260px;
+  max-width: 100%;
+  max-height: 100%;
+  position: relative;
+  cursor: pointer;
+  aspect-ratio: 16/9;
+
+  @media (min-width: 768px) {
+    max-width: 320px;
+    max-height: 320px;
+  }
+
+  img {
+    width: 100%;
+    object-fit: contain;
+  }
+`;
+
+const MessageFile = ({ file, onClick }) => {
+  const b64 = useMemo(() => getBase64Url(file), [file]);
+
+  if (!b64) {
+    return null;
+  }
+
+  const fileType = file["content-type"].split("/")[0];
+
+  return (
+    <Container>
+      <FileRenderer type={fileType} data={b64} onClick={onClick} />
+    </Container>
+  );
+};
+
+export default MessageFile;

--- a/src/components/dashboard/MessageFiles.js
+++ b/src/components/dashboard/MessageFiles.js
@@ -1,0 +1,43 @@
+import { useState } from "react";
+import styled from "styled-components";
+import MessageFile from "./MessageFile";
+import FilePreviewModal from "./modals/FilePreviewModal";
+
+const Container = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  margin: 8px 0;
+  padding: 8px 16px 12px 0;
+  position: relative;
+  gap: 8px;
+`;
+
+const MessageFiles = ({ files }) => {
+  const [selectedFile, setSelectedFile] = useState(null);
+
+  if (!files || files.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      <Container>
+        {files.map((file, i) => (
+          <MessageFile
+            key={i}
+            file={file}
+            onClick={() => setSelectedFile(file)}
+          />
+        ))}
+      </Container>
+
+      <FilePreviewModal
+        open={!!selectedFile}
+        file={selectedFile}
+        onClose={() => setSelectedFile(null)}
+      />
+    </>
+  );
+};
+
+export default MessageFiles;

--- a/src/components/dashboard/WriteArea.js
+++ b/src/components/dashboard/WriteArea.js
@@ -122,8 +122,9 @@ const WriteArea = () => {
 
       event.preventDefault();
       const content = event.target.msg_content.value;
+      const hasContent = content !== "" || pendingFiles.length > 0;
       setMessageContent("");
-      if (content !== "" && (paymail || profile?.paymail || pandaProfile)) {
+      if (hasContent && (paymail || profile?.paymail || pandaProfile)) {
         event.target.reset();
         try {
           await sendMessage(
@@ -264,23 +265,22 @@ const WriteArea = () => {
             )}
           </div>
         )}
-        {/* Images only enabled for HandCash users */}
-        {profile && (
-          <div
-            className="flex items-center justify-center absolute left-0 h-full w-12 cursor-pointer"
-            onClick={(e) => {
-              if (
-                signStatus === FetchStatus.Loading ||
-                postStatus === FetchStatus.Loading
-              ) {
-                return;
-              }
-              dispatch(toggleFileUpload());
-            }}
-          >
-            <HiPlusCircle className="text-2xl ml-2 text-[#aaa]" />
-          </div>
-        )}
+
+        <div
+          className="flex items-center justify-center absolute left-0 h-full w-12 cursor-pointer"
+          onClick={(e) => {
+            if (
+              signStatus === FetchStatus.Loading ||
+              postStatus === FetchStatus.Loading
+            ) {
+              return;
+            }
+            dispatch(toggleFileUpload());
+          }}
+        >
+          <HiPlusCircle className="text-2xl ml-2 text-[#aaa]" />
+        </div>
+
         <ChannelTextArea
           type="text"
           id="channelTextArea"

--- a/src/components/dashboard/WriteArea.js
+++ b/src/components/dashboard/WriteArea.js
@@ -264,10 +264,10 @@ const WriteArea = () => {
             )}
           </div>
         )}
-        {/* Images only enabled for relay users */}
-        {paymail && (
+        {/* Images only enabled for HandCash users */}
+        {profile && (
           <div
-            className="flex items-center justify-center absolute left-0 h-full w-12"
+            className="flex items-center justify-center absolute left-0 h-full w-12 cursor-pointer"
             onClick={(e) => {
               if (
                 signStatus === FetchStatus.Loading ||
@@ -286,7 +286,7 @@ const WriteArea = () => {
           id="channelTextArea"
           name="msg_content"
           autocomplete="off"
-          className={paymail ? `pl-12` : `pl-4`}
+          className={profile ? `pl-12` : `pl-4`}
           placeholder={
             !activeUser?.idKey && activeUser
               ? `DMs Disabled`
@@ -337,7 +337,10 @@ const WriteArea = () => {
       <TypingStatus>
         {typingUser && `${typingUser.paymail} is typing...`}
       </TypingStatus>
-      <PlusModal open={showPlusPopover} onClose={inputRef.current?.focus()} />
+      <PlusModal
+        open={showPlusPopover}
+        onClose={() => inputRef.current?.focus()}
+      />
     </Container>
   );
 };

--- a/src/components/dashboard/modals/FilePreviewModal.js
+++ b/src/components/dashboard/modals/FilePreviewModal.js
@@ -1,0 +1,63 @@
+import React, { useMemo } from "react";
+import OutsideClickHandler from "react-outside-click-handler";
+import styled from "styled-components";
+import { getBase64Url } from "../../../utils/file";
+
+const PopupMessageContainer = styled.div`
+  padding: 16px;
+`;
+
+const PopupContainer = styled.div`
+  background-color: var(--background-primary);
+  color: var(--text-normal);
+  top: 50%;
+  left: 50%;
+  position: absolute;
+  transform: translateX(-50%) translateY(-50%);
+  border-radius: 4px;
+  width: 100%;
+  max-width: 90%;
+
+  @media (min-width: 768px) {
+    width: 40%;
+  }
+`;
+
+const Image = styled.img`
+  width: 100%;
+`;
+
+const FilePreviewModal = ({ open, onClose, file }) => {
+  const b64 = useMemo(() => getBase64Url(file), [file]);
+
+  if (!b64) {
+    return null;
+  }
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        zIndex: 1000,
+        width: "100vw",
+        height: "100dvh",
+        background: `rgba(0,0,0,.5)`,
+        alignItems: "center",
+        justifyContent: "center",
+        display: `${open ? "flex" : "none"}`,
+        pointerEvents: `${open ? "unset" : "none"}`,
+      }}
+      className="top-0 left-0"
+    >
+      <OutsideClickHandler onOutsideClick={onClose}>
+        <PopupContainer className="disable-select">
+          <PopupMessageContainer>
+            <Image src={b64} />
+          </PopupMessageContainer>
+        </PopupContainer>
+      </OutsideClickHandler>
+    </div>
+  );
+};
+
+export default FilePreviewModal;

--- a/src/utils/file.js
+++ b/src/utils/file.js
@@ -1,3 +1,8 @@
+/**
+ * Converts a file to base64 format.
+ * @param {File} file - The file to be converted.
+ * @returns {Promise<string>} - A promise that resolves with the base64 representation of the file.
+ */
 export const toB64 = (file) =>
   new Promise((resolve, reject) => {
     const reader = new FileReader();
@@ -6,8 +11,16 @@ export const toB64 = (file) =>
     reader.readAsDataURL(file);
   });
 
+/**
+ * The maximum file size limit for file uploads.
+ */
 export const UPLOAD_FILE_SIZE_LIMIT = 1024 * 50; // 50kb
 
+/**
+ * Formats the given number of bytes into a human-readable string.
+ * @param {number} bytes - The number of bytes.
+ * @returns {string} - The formatted string representing the file size.
+ */
 export function formatBytes(bytes) {
   if (bytes < 1024) {
     return bytes + "B";
@@ -18,6 +31,40 @@ export function formatBytes(bytes) {
   }
 }
 
+/**
+ * Checks if the given MIME type can be played by an audio or video element.
+ * @param {string} mimeType - The MIME type to check.
+ * @returns {boolean} - True if the MIME type can be played, false otherwise.
+ */
+function canPlayType(mimeType) {
+  if (!mimeType) {
+    return false;
+  }
+
+  const elementType = mimeType.startsWith("audio")
+    ? "audio"
+    : mimeType.startsWith("video")
+    ? "video"
+    : null;
+
+  if (!elementType) {
+    return false;
+  }
+
+  const dummyMediaElement = document.createElement(elementType);
+  if (!dummyMediaElement.canPlayType) {
+    console.log("canPlayType is not supported");
+    return false;
+  }
+
+  return !!dummyMediaElement.canPlayType(mimeType);
+}
+
+/**
+ * Validates the given file based on its size and type.
+ * @param {File} file - The file to validate.
+ * @returns {object} - An object with the validation result and error message (if any).
+ */
 export function validateFile(file) {
   if (file.size > UPLOAD_FILE_SIZE_LIMIT) {
     return {
@@ -26,9 +73,8 @@ export function validateFile(file) {
     };
   }
 
-  const isTypeSupported = ["image", "audio", "video"].some((t) =>
-    file.type.includes(t)
-  );
+  const isImage = file.type.startsWith("image");
+  const isTypeSupported = isImage || canPlayType(file.type);
 
   if (!isTypeSupported) {
     return {
@@ -40,6 +86,11 @@ export function validateFile(file) {
   return { valid: true, error: "" };
 }
 
+/**
+ * Gets the base64 URL of a B file.
+ * @param {object} bFile - The B file object containing the base64 data and content type.
+ * @returns {string|null} - The base64 URL of the file, or null if the file object is invalid.
+ */
 export function getBase64Url(bFile) {
   if (!bFile || !bFile.Data || !bFile["content-type"]) {
     return null;

--- a/src/utils/file.js
+++ b/src/utils/file.js
@@ -1,0 +1,56 @@
+export const toB64 = (file) =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result);
+    reader.onerror = (error) => reject(error);
+    reader.readAsDataURL(file);
+  });
+
+export const UPLOAD_FILE_SIZE_LIMIT = 1024 * 50; // 50kb
+
+export function formatBytes(bytes) {
+  if (bytes < 1024) {
+    return bytes + "B";
+  } else if (bytes < 1024 * 1024) {
+    return (bytes / 1024).toFixed(0) + "KB";
+  } else {
+    return (bytes / (1024 * 1024)).toFixed(0) + "MB";
+  }
+}
+
+export function validateFile(file) {
+  if (file.size > UPLOAD_FILE_SIZE_LIMIT) {
+    return {
+      valid: false,
+      error: "File size exceeds the limit. Please choose a smaller file.",
+    };
+  }
+
+  const isTypeSupported = ["image", "audio", "video"].some((t) =>
+    file.type.includes(t)
+  );
+
+  if (!isTypeSupported) {
+    return {
+      valid: false,
+      error: "File type not supported. Please choose a different file.",
+    };
+  }
+
+  return { valid: true, error: "" };
+}
+
+export function getBase64Url(bFile) {
+  if (!bFile || !bFile.Data || !bFile["content-type"]) {
+    return null;
+  }
+
+  const b64Data = bFile.Data.utf8;
+  const contentType = bFile["content-type"];
+
+  if (!b64Data || !contentType) {
+    return null;
+  }
+
+  return `data:${contentType};base64,${b64Data}`;
+}


### PR DESCRIPTION
This PR adds support for publishing and displaying files within chat.

### Limitations

- File size - due to bmap indexer API upload limit, the largest file that can be uploaded is 50kb (due to default upload limit of 100kb, and the signature practically doubling the payload size). After the indexer upload limit is increased, we should modify the UPLOAD_FILE_SIZE_LIMIT constant to match. Also to keep in mind, HandCash seems to also have an upload size limit (theirs is around 1MB I think).

### Test cases:
- Select a file that cannot be played in the browser (e.g. .mov)
    - The file picker modal will show an error message that the file type is not supported
- Select a file that is larger than 50KB
    - The file picker modal will show an error message that the file is too large
- Select a supported file within the size limit and hit send
    - A message containing the file data will be published to blockchain
    - The message will appear in the chat, displaying the file
- Select three files, enter the message, and hit send
    - A message containing the file data will be published to blockchain
    - The message will appear in the chat, displaying the text and files
- Click on an image within chat
    - A larger version of an image will be opened in modal

### Demo

https://github.com/rohenaz/allaboard-bitchat-nitro/assets/160716963/baeea0a4-7d93-415f-b534-03365276a1e6
