### PR TITLE
Display messages from Panda wallet as unverified

### DIFF
--- a/src/components/dashboard/Header.js
+++ b/src/components/dashboard/Header.js
@@ -2,6 +2,7 @@ import React, { useMemo } from "react";
 
 import {
   FaBars,
+  FaCog,
   FaGithub,
   FaSignInAlt,
   FaSignOutAlt,
@@ -23,6 +24,8 @@ import { toggleSidebar } from "../../reducers/sidebarReducer";
 import ArrowTooltip from "./ArrowTooltip";
 import At from "./At";
 import Hashtag from "./Hashtag";
+import { toggleSettings } from "../../reducers/settingsReducer";
+import { SettingsModal } from "./modals/SettingsModal";
 
 const Container = styled.div`
   background-color: var(--background-primary);
@@ -109,6 +112,11 @@ const Header = ({ isFriendsPage }) => {
         </div>
       </div>
       <div className="flex flex-1 justify-end">
+        <ArrowTooltip title="Settings">
+          <IconButton onClick={() => dispatch(toggleSettings())}>
+            <FaCog />
+          </IconButton>
+        </ArrowTooltip>
         <ArrowTooltip title="GitHub Repo">
           <IconButton
             href="https://github.com/rohenaz/allaboard-bitchat-nitro"
@@ -150,6 +158,7 @@ const Header = ({ isFriendsPage }) => {
           </ArrowTooltip>
         )}
       </div>
+      <SettingsModal />
     </Container>
   );
 };

--- a/src/components/dashboard/Message.js
+++ b/src/components/dashboard/Message.js
@@ -13,6 +13,9 @@ import { useBitcoin } from "../../context/bitcoin";
 import { useHandcash } from "../../context/handcash";
 import { useRelay } from "../../context/relay";
 import ArrowTooltip from "./ArrowTooltip";
+import { isValidEmail } from "../../utils/strings";
+import { FaCheckCircle } from "react-icons/fa";
+import Avatar from "./Avatar";
 
 const md = new Remarkable({
   html: true,
@@ -21,8 +24,6 @@ const md = new Remarkable({
   linkTarget: "_blank",
 });
 md.renderer = new RemarkableReactRenderer();
-
-import Avatar from "./Avatar";
 
 const MessageButtons = styled.div`
   background-color: var(--background-primary);
@@ -84,6 +85,12 @@ const Username = styled.a`
     text-decoration: underline;
     cursor: pointer;
   }
+`;
+
+const InfoContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
 `;
 
 const Timestamp = styled.div`
@@ -202,6 +209,7 @@ const Message = ({ message, reactions, appIcon, handleClick }) => {
   const { paymail } = useRelay();
   const { profile } = useHandcash();
   const { likeMessage, likeStatus } = useBitcoin();
+  const isVerified = isValidEmail(head(message.MAP).paymail || "");
   // const handleSubmit = (event) => {
   //   event.preventDefault();
   //   const content = event.target.value;
@@ -389,17 +397,22 @@ const Message = ({ message, reactions, appIcon, handleClick }) => {
                 </div>
               )}
             </div>
-            <a
-              href={`https://whatsonchain.com/tx/${message.tx.h}`}
-              target="_blank"
-            >
-              <Timestamp>
-                {message.timestamp
-                  ? moment.unix(message.timestamp).fromNow()
-                  : moment.unix(message.blk.t).fromNow()}
-                {/* {message.editedAt ? " (edited)" : ""} */}
-              </Timestamp>
-            </a>
+
+            <InfoContainer>
+              {isVerified && <FaCheckCircle color="green" />}
+
+              <a
+                href={`https://whatsonchain.com/tx/${message.tx.h}`}
+                target="_blank"
+              >
+                <Timestamp>
+                  {message.timestamp
+                    ? moment.unix(message.timestamp).fromNow()
+                    : moment.unix(message.blk.t).fromNow()}
+                  {/* {message.editedAt ? " (edited)" : ""} */}
+                </Timestamp>
+              </a>
+            </InfoContainer>
           </div>
         </Header>
         {/* {showTextArea ? (

--- a/src/components/dashboard/modals/SettingsModal.js
+++ b/src/components/dashboard/modals/SettingsModal.js
@@ -1,0 +1,57 @@
+import React from "react";
+import styled from "styled-components";
+import {
+  toggleHideUnverifiedMessages,
+  toggleSettings,
+} from "../../../reducers/settingsReducer";
+import { useDispatch, useSelector } from "react-redux";
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  FormControlLabel,
+  FormGroup,
+  Switch,
+} from "@mui/material";
+
+const SettingsContainer = styled.div`
+  box-shadow: 24px;
+  padding: 1rem;
+`;
+
+const Label = styled.label`
+  font-family: var(--font);
+`;
+
+export const SettingsModal = () => {
+  const dispatch = useDispatch();
+  const { isOpen, hideUnverifiedMessages } = useSelector(
+    (state) => state.settings
+  );
+
+  return (
+    <Dialog
+      open={isOpen}
+      onClose={() => {
+        dispatch(toggleSettings());
+      }}
+    >
+      <SettingsContainer>
+        <DialogTitle fontFamily="var(--font)">Settings</DialogTitle>
+        <DialogContent>
+          <FormGroup>
+            <FormControlLabel
+              control={
+                <Switch
+                  onChange={() => dispatch(toggleHideUnverifiedMessages())}
+                  checked={hideUnverifiedMessages}
+                />
+              }
+              label={<Label>Hide unverified messages</Label>}
+            />
+          </FormGroup>
+        </DialogContent>
+      </SettingsContainer>
+    </Dialog>
+  );
+};

--- a/src/context/bitcoin/index.js
+++ b/src/context/bitcoin/index.js
@@ -549,8 +549,14 @@ const BitcoinProvider = (props) => {
 
           // console.log("made a tx to send to panda", { tx, r });
 
-          const tx = await notifyIndexer(rawtx);
-          console.log("indexer notified", { tx });
+          try {
+            const tx = await notifyIndexer(rawtx);
+            console.log("indexer notified", { tx });
+            setPostStatus(FetchStatus.Success);
+          } catch (e) {
+            console.log("notifying indexer failed", e);
+            setPostStatus(FetchStatus.Error);
+          }
           return;
         }
 

--- a/src/reducers/chatReducer.js
+++ b/src/reducers/chatReducer.js
@@ -96,15 +96,9 @@ const chatSlice = createSlice({
     },
     receiveNewMessage(state, action) {
       // TODO: If channel is set, update channel updateAt time
-
       const message = action.payload;
       const myBapId = message.myBapId;
-      if (
-        (!head(message.MAP).context ||
-          head(message.MAP).context === "channel") &&
-        head(message.MAP).paymail &&
-        !validateEmail(head(message.MAP).paymail)
-      ) {
+      if (!head(message.MAP).context) {
         console.log("invalid message", message);
         return;
       }
@@ -203,13 +197,6 @@ const chatSlice = createSlice({
         state.messages.allIds = [];
         state.messages.loading = false;
         (action.payload?.message || []).forEach((message) => {
-          if (
-            head(message.MAP).paymail &&
-            !validateEmail(head(message.MAP).paymail)
-          ) {
-            return;
-          }
-
           // Filter out txs with wrong encoding (oops)
           if (
             head(message.B).encoding === "utf-8" &&

--- a/src/reducers/settingsReducer.js
+++ b/src/reducers/settingsReducer.js
@@ -1,0 +1,42 @@
+import { createSlice } from "@reduxjs/toolkit";
+import { loadFromLocalStorage, saveInLocalStorage } from "../utils/storage";
+
+export const SETTINGS_OPTIONS = Object.freeze({
+  HIDE: "HIDE",
+  SHOW: "SHOW",
+});
+
+const hideUnverifiedMessagesInitState =
+  loadFromLocalStorage("settings.hideUnverifiedMessages") ===
+  SETTINGS_OPTIONS.HIDE
+    ? false
+    : true;
+
+const initialState = {
+  hideUnverifiedMessages: hideUnverifiedMessagesInitState,
+  isOpen: false,
+};
+
+const settingsSlice = createSlice({
+  name: "settings",
+  initialState,
+  reducers: {
+    toggleHideUnverifiedMessages(state) {
+      state.hideUnverifiedMessages = !state.hideUnverifiedMessages;
+      saveInLocalStorage(
+        "settings.hideUnverifiedMessages",
+        state.hideUnverifiedMessages
+          ? SETTINGS_OPTIONS.SHOW
+          : SETTINGS_OPTIONS.HIDE
+      );
+    },
+    toggleSettings(state) {
+      state.isOpen = !state.isOpen;
+    },
+  },
+});
+
+export const { toggleSettings, toggleHideUnverifiedMessages } =
+  settingsSlice.actions;
+
+export default settingsSlice.reducer;

--- a/src/store.js
+++ b/src/store.js
@@ -7,6 +7,7 @@ import memberListReducer from "./reducers/memberListReducer";
 import profileReducer from "./reducers/profileReducer";
 import sessionReducer from "./reducers/sessionReducer";
 import sidebarReducer from "./reducers/sidebarReducer";
+import settingsReducer from "./reducers/settingsReducer";
 
 const store = configureStore({
   reducer: {
@@ -16,6 +17,7 @@ const store = configureStore({
     sidebar: sidebarReducer,
     memberList: memberListReducer,
     profile: profileReducer,
+    settings: settingsReducer,
   },
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware({ serializableCheck: false }).concat(socketMiddleware),

--- a/src/utils/strings.js
+++ b/src/utils/strings.js
@@ -5,3 +5,5 @@ export const validateEmail = (email) => {
       /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
     );
 };
+
+export const isValidEmail = (candidate) => Boolean(validateEmail(candidate));


### PR DESCRIPTION
- added Settings icon and dialog, and settingsReducer
- added option to hide unverified messages (saving in localStorage, default = SHOW)
- fetch all messages and display unverified unless switched off in settings
- fixed "Pending..." placeholder after a message from Panda user is sent to indexer