### PR TITLE
Fix - update content type property

### DIFF
--- a/src/components/dashboard/Message.js
+++ b/src/components/dashboard/Message.js
@@ -302,7 +302,9 @@ const Message = ({ message, reactions, appIcon, handleClick }) => {
      * If there is no text message, we don't want to render it.
      * This can happen when a message contains only file(s).
      */
-    if (head(m.B)?.["content-type"] !== "text/plain") {
+    const contentType =
+      head(m.B)?.["content-type"] ?? head(m.B)?.["media_type"];
+    if (contentType !== "text/plain") {
       return null;
     }
 

--- a/src/components/dashboard/MessageFile.js
+++ b/src/components/dashboard/MessageFile.js
@@ -32,7 +32,8 @@ const MessageFile = ({ file, onClick }) => {
     return null;
   }
 
-  const fileType = file["content-type"].split("/")[0];
+  const contentType = file["content-type"] ?? file["media_type"];
+  const fileType = contentType.split("/")[0];
 
   return (
     <Container>


### PR DESCRIPTION
It seems that there is no longer a "content-type" property coming from the indexer, but a "media_type" property.

Added a fallback to check for both we can render the message text.

Before:
![image](https://github.com/rohenaz/allaboard-bitchat-nitro/assets/160716963/7175343e-feab-4641-a823-cdcdcca5acc7)


After:
![image](https://github.com/rohenaz/allaboard-bitchat-nitro/assets/160716963/3f55436e-1c49-4565-969e-682577227a7b)
